### PR TITLE
Make unity build and precompiled headers optional

### DIFF
--- a/VistaCoreLibs/CMakeLists.txt
+++ b/VistaCoreLibs/CMakeLists.txt
@@ -93,17 +93,14 @@ endif( NOT VISTACORELIBS_SUPPORT_NATIVE_64BIT_ATOMICS )
 # endif()
 
 if (${CMAKE_VERSION} GREATER_EQUAL 3.16)
-	set(CMAKE_UNITY_BUILD On)
+	option(VISTA_USE_PRECOMPILED_HEADERS "Turn on generation of precompiled headers" OFF)
+
 	set(CMAKE_UNITY_BUILD_BATCH_SIZE 20)
 	add_definitions(
 		-D_WINSOCK_DEPRECATED_NO_WARNINGS
 		-D_WINSOCKAPI_
 		-DNOMINMAX
 	)
-
-	if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-		set(VISTA_ENABLE_PCH true)
-	endif()
 endif()
 
 # Standard package config

--- a/VistaCoreLibs/VistaAspects/CMakeLists.txt
+++ b/VistaCoreLibs/VistaAspects/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries( VistaAspects
 	${LIBRARIES}
 )
 
-if (${VISTA_ENABLE_PCH})
+if (VISTA_USE_PRECOMPILED_HEADERS)
 	target_precompile_headers(VistaAspects PRIVATE precompiled.pch)
 endif()
 

--- a/VistaCoreLibs/VistaBase/CMakeLists.txt
+++ b/VistaCoreLibs/VistaBase/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries( VistaBase
 	${LIBRARIES}
 )
 
-if (${VISTA_ENABLE_PCH})
+if (VISTA_USE_PRECOMPILED_HEADERS)
 	target_precompile_headers(VistaBase PRIVATE precompiled.pch)
 endif()
 

--- a/VistaCoreLibs/VistaDataFlowNet/CMakeLists.txt
+++ b/VistaCoreLibs/VistaDataFlowNet/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries( VistaDataFlowNet
 	${VISTADATAFLOWNET_INTERNAL_DEPENDENCIES}
 )
 
-if (${VISTA_ENABLE_PCH})
+if (VISTA_USE_PRECOMPILED_HEADERS)
 	target_precompile_headers(VistaDataFlowNet PRIVATE precompiled.pch)
 endif()
 

--- a/VistaCoreLibs/VistaDeviceDriversBase/CMakeLists.txt
+++ b/VistaCoreLibs/VistaDeviceDriversBase/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries( VistaDeviceDriversBase
 	${LIBRARIES}
 )
 
-if (${VISTA_ENABLE_PCH})
+if (VISTA_USE_PRECOMPILED_HEADERS)
 	target_precompile_headers(VistaDeviceDriversBase PRIVATE precompiled.pch)
 endif()
 

--- a/VistaCoreLibs/VistaInterProcComm/CMakeLists.txt
+++ b/VistaCoreLibs/VistaInterProcComm/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries( VistaInterProcComm
 	${LIBRARIES}
 )
 
-if (${VISTA_ENABLE_PCH})
+if (VISTA_USE_PRECOMPILED_HEADERS)
 	target_precompile_headers(VistaInterProcComm PRIVATE precompiled.pch)
 endif()
 

--- a/VistaCoreLibs/VistaKernel/CMakeLists.txt
+++ b/VistaCoreLibs/VistaKernel/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries( VistaKernel
 	${VISTA_USE_PACKAGE_LIBRARIES}
 )
 
-if (${VISTA_ENABLE_PCH})
+if (VISTA_USE_PRECOMPILED_HEADERS)
 	target_precompile_headers(VistaKernel PRIVATE precompiled.pch)
 endif()
 

--- a/VistaCoreLibs/VistaKernelOpenSGExt/CMakeLists.txt
+++ b/VistaCoreLibs/VistaKernelOpenSGExt/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries( VistaKernelOpenSGExt
 	${VISTA_USE_PACKAGE_LIBRARIES}
 )
 
-if (${VISTA_ENABLE_PCH})
+if (VISTA_USE_PRECOMPILED_HEADERS)
 	target_precompile_headers(VistaKernelOpenSGExt PRIVATE precompiled.pch)
 endif()
 

--- a/VistaCoreLibs/VistaMath/CMakeLists.txt
+++ b/VistaCoreLibs/VistaMath/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries( VistaMath
 	${VISTAMATH_INTERNAL_DEPENDENCIES}
 )
 
-if (${VISTA_ENABLE_PCH})
+if (VISTA_USE_PRECOMPILED_HEADERS)
 	target_precompile_headers(VistaMath PRIVATE precompiled.pch)
 endif()
 

--- a/VistaCoreLibs/VistaOGLExt/CMakeLists.txt
+++ b/VistaCoreLibs/VistaOGLExt/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries( VistaOGLExt
 	${VISTA_USE_PACKAGE_LIBRARIES}
 )
 
-if (${VISTA_ENABLE_PCH})
+if (VISTA_USE_PRECOMPILED_HEADERS)
 	target_precompile_headers(VistaOGLExt PRIVATE precompiled.pch)
 endif()
 

--- a/VistaCoreLibs/VistaTools/CMakeLists.txt
+++ b/VistaCoreLibs/VistaTools/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries( VistaTools
 	${LIBRARIES}
 )
 
-if (${VISTA_ENABLE_PCH})
+if (VISTA_USE_PRECOMPILED_HEADERS)
 	target_precompile_headers(VistaTools PRIVATE precompiled.pch)
 endif()
 


### PR DESCRIPTION
Especially the Linux runners of Github Actions seem to benefit more from ccache when precompiled headers are deactivated.