### PR TITLE
Support infinite reverse projection for steam vr.

### DIFF
--- a/VistaCoreLibs/VistaKernel/CMakeLists.txt
+++ b/VistaCoreLibs/VistaKernel/CMakeLists.txt
@@ -54,6 +54,11 @@ if( VISTACORELIBS_USE_VIVE )
 	add_definitions( -DVISTA_WITH_VIVE )
 endif()
 
+set( VISTACORELIBS_USE_INFINITE_REVERSE_PROJECTION OFF CACHE BOOL "if activated, matrices will be modified to use infinite reverse projection" )
+if( VISTACORELIBS_USE_INFINITE_REVERSE_PROJECTION )
+	add_definitions( -DVISTA_VIVE_INFINITE_REVERSE_PROJECTION )
+endif()
+
 if( NOT VISTACORELIBS_BUILD_WINDOWIMP_GLUT AND NOT VISTACORELIBS_BUILD_WINDOWIMP_OSG )
 	message( WARNING "No Windowing Toolkit will be built!" )
 endif()

--- a/VistaCoreLibs/VistaKernel/OpenSG/VistaOpenSGDisplayBridge.cpp
+++ b/VistaCoreLibs/VistaKernel/OpenSG/VistaOpenSGDisplayBridge.cpp
@@ -239,6 +239,7 @@ namespace
 		void UpdateViveProjection( float fNear, float fFar )
 		{
 			// ovrMatrix4f matLeftProjection = ovrMatrix4f_Projection( m_apRenderDescs[0].Fov, fNear, fFar, true );
+
 	        auto const& matLeftProjection = m_pVRSystem->GetProjectionMatrix(
 	            vr::EVREye::Eye_Left, fNear, fFar
 	        );
@@ -250,6 +251,15 @@ namespace
 					matOSGProjection[j][i] = matLeftProjection.m[i][j]; // !!!!!!!TEST: row or column major?????
 				}
 			}
+
+#ifdef VISTA_VIVE_INFINITE_REVERSE_PROJECTION
+                        // If a reverse infinite projection is used, we have to modify the projection matrix.
+                        // See Equation (4) in https://dx.doi.org/10.18420/vrar2021_12
+                        float n2 = 2.f * fNear;
+                        matOSGProjection[2][2] = 1.f;
+                        matOSGProjection[3][2] = n2;
+#endif // VISTA_VIVE_INFINITE_REVERSE_PROJECTION
+
 			beginEditCP( m_pLeftCamera );
 			m_pLeftCamera->setProjectionMatrix( matOSGProjection );
 			endEditCP( m_pLeftCamera );
@@ -265,6 +275,14 @@ namespace
 					matOSGProjection[j][i] = matRightProjection.m[i][j];// !!!!!!!TEST: row or column major?????
 				}
 			}
+
+#ifdef VISTA_VIVE_INFINITE_REVERSE_PROJECTION
+                        // If a reverse infinite projection is used, we have to modify the projection matrix.
+                        // See Equation (4) in https://dx.doi.org/10.18420/vrar2021_12
+                        matOSGProjection[2][2] = 1.f;
+                        matOSGProjection[3][2] = n2;
+#endif // VISTA_VIVE_INFINITE_REVERSE_PROJECTION
+
 			beginEditCP( m_pRightCamera );
 			m_pRightCamera->setProjectionMatrix( matOSGProjection );
 			endEditCP( m_pRightCamera );


### PR DESCRIPTION
The support can be enable via the CMake flag: `VISTACORELIBS_USE_INFINITE_REVERSE_PROJECTION`