### PR TITLE
Fix wrong include order with glew.h and gl.h.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,3 +21,4 @@ DerivePointerAlignment: false
 PointerAlignment: Left
 Standard: Cpp11
 SpacesInContainerLiterals: false
+SortIncludes: false

--- a/VistaCoreLibs/VistaKernel/OpenSG/VistaOpenSGDisplayBridge.cpp
+++ b/VistaCoreLibs/VistaKernel/OpenSG/VistaOpenSGDisplayBridge.cpp
@@ -32,8 +32,8 @@
 #include <winsock2.h> // sigh, we dont need it. but glew includes windows.h, which may not be included
                       // before winsocks, whcih may be included by oculus sdk, so...
 #endif
-#include <GL/gl.h>
 #include <GL/glew.h>
+#include <GL/gl.h>
 
 #include "VistaOpenSGDisplayBridge.h"
 


### PR DESCRIPTION
This fixes the glew.h and gl.h include order. Also disabled include ordering in clang-format.